### PR TITLE
linkedHeadings: linked headings to ids

### DIFF
--- a/_docs/scripts/linkedHeadings.js
+++ b/_docs/scripts/linkedHeadings.js
@@ -1,3 +1,3 @@
-$('h2, h3').filter('[id]').each(function () {
+$('h1, h2, h3, h4').filter('[id]').each(function () {
     $(this).html('<a href="#'+$(this).attr('id')+'">' + $(this).text() + '</a>');
 });

--- a/_docs/scripts/linkedHeadings.js
+++ b/_docs/scripts/linkedHeadings.js
@@ -1,0 +1,3 @@
+$('h2, h3').filter('[id]').each(function () {
+    $(this).html('<a href="#'+$(this).attr('id')+'">' + $(this).text() + '</a>');
+});

--- a/book.json
+++ b/book.json
@@ -11,7 +11,8 @@
      "scripts": {
         "files": [
           "scripts/injectLogo.js",
-          "scripts/analytics.js"
+          "scripts/analytics.js",
+          "scripts/linkedHeadings.js"
         ]
     },
     "fontSettings": {


### PR DESCRIPTION
## Problem

We often want to link to specific sections in the spec, but cannot do this easily because the headings aren't linked as anchors.
For example, we can go to http://opentracing.io/documentation/pages/spec#spans directly, but discovering this link exists is not straightforward.  I'd expect to click on this heading to change the url to one including the anchor id.
http://screencast.com/t/hL6HchXXO

## Solution

Rather than edit every occurrence of h2 and h3 tags, the approach taken in this change is to simply auto-wrap these in anchor tags via javascript.  This will apply to all h2 or h3 tags, regardless of page.
http://screencast.com/t/UlCpHo5TM
