### PR TITLE
fix **Data Conventions Guideline** on Logs section

### DIFF
--- a/_docs/pages/spec.md
+++ b/_docs/pages/spec.md
@@ -100,7 +100,7 @@ These can all be valid timing diagrams for children that "FollowFrom" a parent.
 
 Every Span has zero or more **Logs**, each of which being a timestamped event name, optionally accompanied by a structured data payload of arbitrary size. The event name should be the stable identifier for some notable moment in the lifetime of a Span. For instance, a Span representing a browser page load might add an event for each field in [Performance.timing](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming).
 
-While it is not a formal requirement, specific event names should apply to many Span instances: tracing systems can use these event names (and timestamps) to analyze Spans in the aggregate.  For more information, see the [Data Semantics Guidelines](api/data-conventions).
+While it is not a formal requirement, specific event names should apply to many Span instances: tracing systems can use these event names (and timestamps) to analyze Spans in the aggregate.  For more information, see the [Data Conventions Guidelines](api/data-conventions).
 
 <span id="tags"></span>
 


### PR DESCRIPTION
Section **Logs** has the same problem on **Data Conventions Guideline** with section **Tags**. add a new RP to fix it.
