### PR TITLE
fix ios render bug

### DIFF
--- a/_sass/_components/_logo-bar.scss
+++ b/_sass/_components/_logo-bar.scss
@@ -28,7 +28,6 @@ $logo-bar-scale: 14px;
 
   &__logos {
     max-width: $medium / 2;
-    min-width: $medium / 2;
     height: 75px;
     overflow-x: hidden;
     display: flex;
@@ -106,7 +105,7 @@ $logo-bar-scale: 14px;
   @media (max-width: $medium) {
     &__logos {
       max-width: 100%;
-      min-width: 100%;
+      width: 100%;
       min-height: 65px;
 
       &:before {


### PR DESCRIPTION
Tracers and frameworks on certain viewports got a weird render bug that
caused both frameworks and tracers to render on the same row as Tracers.