### PR TITLE
Adjust contrib link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,11 +20,12 @@
           {% for language in site.data.language.array %}
             <a href="{{language.url}}">{{ language.name }}</a>
           {% endfor %}
+          <hr/>
+          <a href="https://github.com/opentracing-contrib/meta">Contributions</a>
         </div>
       </div>
 
       <a href="https://medium.com/opentracing">Blog</a>
-      <a href="https://github.com/opentracing-contrib/meta">Contributions</a>
     </div>
     <div class="header__actions right">
       <a class="button white" href="https://groups.google.com/forum/#!forum/opentracing">Join the mailing list</a>
@@ -50,6 +51,8 @@
       {% for language in site.data.language.array %}
         <a href="{{language.url}}">{{ language.name }}</a>
       {% endfor %}
+      <hr/>
+      <a href="https://github.com/opentracing-contrib/meta">Contributions</a>
 
       <h3>Mailing List</h3>
       <a href="https://groups.google.com/forum/#!forum/opentracing">Join!</a>


### PR DESCRIPTION
I moved it back under the "Github" menu in an effort to keep the landing page (more) uncluttered...