### PR TITLE
pages/quick-start: HTTPHeaderTextMapCarrier -> HTTPHeadersCarrier

### DIFF
--- a/_docs/pages/quick-start.md
+++ b/_docs/pages/quick-start.md
@@ -118,7 +118,7 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
     // Inject the span context into the header
     err := span.Tracer().Inject(span.Context(),
         opentracing.TextMap,
-        opentracing.HTTPHeaderTextMapCarrier(asyncReq.Header))
+        opentracing.HTTPHeadersCarrier(asyncReq.Header))
     if err != nil {
         log.Fatalf("Could not inject span context into header: %v", err)
     }
@@ -142,7 +142,7 @@ func serviceHandler(w http.ResponseWriter, r *http.Request) {
     // Attempt to join a trace by getting trace context from the headers.
     wireContext, err := opentracing.GlobalTracer().Extract(
         opentracing.TextMap,
-        opentracing.HTTPHeaderTextMapCarrier(r.Header))
+        opentracing.HTTPHeadersCarrier(r.Header))
     if err != nil {
         // If for whatever reason we can't join, go ahead an start a new root span.
         sp = opentracing.StartSpan(opName)


### PR DESCRIPTION
As of [this PR], July 26, 2016, `HTTPHeaderTextMapCarrier` was renamed
to `HTTPHeadersCarrier`.

[this PR]: https://github.com/opentracing/opentracing-go/pull/102

_____

I was following the quick intro and ran into this. I may propose other small edits in the near future if I run into more.