### PR TITLE
Show all videos in the videos section. 

### DIFF
--- a/_sass/_components/_videos.scss
+++ b/_sass/_components/_videos.scss
@@ -50,7 +50,7 @@ $video-spacing: 15px;
         opacity: 0.75;
         color: #45c1de;
         font-size: 1rem;
-        content: 'Other videos and talks';
+        content: 'Other talks and videos';
       }
 
        & > div {
@@ -71,7 +71,7 @@ $video-spacing: 15px;
     }
      &--featured {
       &:before {
-        content: 'Featured videos and talks';
+        content: 'Featured talks and videos';
       }
 
      }

--- a/_talks_and_videos/2016-09-21-advances-in-cassandra.md
+++ b/_talks_and_videos/2016-09-21-advances-in-cassandra.md
@@ -3,6 +3,7 @@ title: "Advances in Cassandra Tracing with Zipkin"
 videoUrl: https://www.youtube.com/embed/I81g27p21Gc
 thumbnail: https://img.youtube.com/vi/I81g27p21Gc/maxresdefault.jpg
 layout: video
+featured: false
 ---
 
 In this talk Mick Semb Wever, Consultant at The Last Pickle, will discuss the formation of the OpenTracing Project, its goals for making tracing ubiquitous, and its work improving the way Zipkin uses Apache Cassandra. He will present examples of tracing application requests through to Cassandra reading from disk, including Zipkin tracing its own operations.

--- a/_talks_and_videos/2016-10-15-an-introduction-to-distributed-tracing-and-zipkin.md
+++ b/_talks_and_videos/2016-10-15-an-introduction-to-distributed-tracing-and-zipkin.md
@@ -3,6 +3,7 @@ title: "An Introduction to Distributed Tracing and Zipkin"
 videoUrl: https://www.youtube.com/embed/_T4x5J0wOVQ
 thumbnail: https://img.youtube.com/vi/_T4x5J0wOVQ/maxresdefault.jpg
 layout: video
+featured: false
 ---
 
 Latency analysis is the act of blaming components for causing user perceptible delay. In today's world of microservices, this can be tricky as requests can fan out across polyglot components and even data-centers. This session will overview how to debug latency and better understand your production environment with Zipkin. You'll see a demo and leave knowing how to get started with distributed tracing.

--- a/_talks_and_videos/2017-02-13-ditributed-tracing-and-containers.md
+++ b/_talks_and_videos/2017-02-13-ditributed-tracing-and-containers.md
@@ -3,6 +3,7 @@ title: "Distributed Tracing and Containers"
 videoUrl: https://www.youtube.com/embed/wD0794Zyed8
 thumbnail: https://img.youtube.com/vi/wD0794Zyed8/maxresdefault.jpg
 layout: video
+featured: false
 ---
 
 Priyanka Sharma [@pritianka](https://twitter.com/pritianka) is an entrepreneur with a passion for building developer products and growing them through open source communities. She heads Marketing and Partnerships at LightStep and also works on the OpenTracing project, an instrumentation standard for distributed tracing. In her copious spare time she advises startups at HeavyBit industries, an accelerator for developer products. Priyanka cofounded WakaTime, an open source time-tracker for developers and holds a BA in Political Science from Stanford University.

--- a/pages/talks_and_videos.html
+++ b/pages/talks_and_videos.html
@@ -5,13 +5,11 @@ layout: default-with-header
 ---
 
 {% assign reversed = site.talks_and_videos | reverse | sort: 'order'  %}
+
 {% assign featuredVideos = reversed | where:"featured", "list"  %}
-{% assign otherVideo = reversed | where:"featured", ""  %}
+{% assign otherVideos = reversed | where:"featured", false  %}
 
 {% assign featuredVideo = (reversed | where:"featured", "big") | first  %}
-
-
-
 {% capture with_read_more %} {{featuredVideo.content | truncatewords: 45 | strip_html }}  <a href="{{ site.url }}/talks-and-videos/{{ featuredVideo.slug }}">..more</a> {% endcapture %}
 
 <section class="videos">
@@ -42,7 +40,7 @@ layout: default-with-header
   </section>
 
   <section class="videos__section--list">
-    {% for video in otherVideo %}
+    {% for video in otherVideos %}
       <div class="videos__content">
         <a href="{{ site.url }}/talks-and-videos/{{ video.slug }}">
           <img src="{{video.thumbnail}}" alt="{{video.title}}">


### PR DESCRIPTION
local build differed from github pages build because Github has updated their dependencies to use 3.4.3 (https://pages.github.com/versions/) which changed how liquid templates handles the case when a variable is non-existing.

This change resulted in condition `  array | where "featured", ""` not getting fullfilled when `featured` was not set.

Fixed this by adding feature variable to all videos. :)