### PR TITLE
Update jaeger URL

### DIFF
--- a/_docs/pages/supported-tracers.md
+++ b/_docs/pages/supported-tracers.md
@@ -6,7 +6,7 @@
 
 ## Jaeger
 
-[Jaeger \\ˈyā-gər\\](http://uber.github.io/jaeger) is Uber's distributed tracing system, built with OpenTracing support from inception. Jaeger includes OpenTracing client libraries in several languages: [Java](https://github.com/uber/jaeger-client-java), [Go](https://github.com/uber/jaeger-client-go), [Python](https://github.com/uber/jaeger-client-python), and [Node.js](https://github.com/uber/jaeger-client-node).
+[Jaeger \\ˈyā-gər\\](https://github.com/jaegertracing/jaeger) is Uber's distributed tracing system, built with OpenTracing support from inception. Jaeger includes OpenTracing client libraries in several languages: [Java](https://github.com/uber/jaeger-client-java), [Go](https://github.com/uber/jaeger-client-go), [Python](https://github.com/uber/jaeger-client-python), and [Node.js](https://github.com/uber/jaeger-client-node).
 
 
 ## Appdash

--- a/_docs/pages/supported-tracers.md
+++ b/_docs/pages/supported-tracers.md
@@ -6,7 +6,7 @@
 
 ## Jaeger
 
-[Jaeger \\ˈyā-gər\\](https://github.com/jaegertracing/jaeger) is Uber's distributed tracing system, built with OpenTracing support from inception. Jaeger includes OpenTracing client libraries in several languages: [Java](https://github.com/uber/jaeger-client-java), [Go](https://github.com/uber/jaeger-client-go), [Python](https://github.com/uber/jaeger-client-python), and [Node.js](https://github.com/uber/jaeger-client-node).
+[Jaeger \\ˈyā-gər\\](http://jaegertracing.io) is Uber's distributed tracing system, built with OpenTracing support from inception. Jaeger includes OpenTracing client libraries in several languages: [Java](https://github.com/uber/jaeger-client-java), [Go](https://github.com/uber/jaeger-client-go), [Python](https://github.com/uber/jaeger-client-python), [Node.js](https://github.com/uber/jaeger-client-node), and [C++](https://github.com/jaegertracing/cpp-client).
 
 
 ## Appdash


### PR DESCRIPTION
The current URL gives 404. I've updated it to point to Github repository.