### PR TITLE
Fix typos and add missing prepositions to pages/documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,5 +88,5 @@ Jekyll temp folder when running `jekyll serve`. You can ignore this.
 static content.
 
 #### css, documentation
-post-build static assets. don't edit these.
+post-build static assets. Don't edit these.
 

--- a/_docs/pages/instrumentation/instrumenting-frameworks.md
+++ b/_docs/pages/instrumentation/instrumenting-frameworks.md
@@ -6,7 +6,7 @@
 
 The audience for this guide are developers interested in adding [OpenTracing](http://opentracing.io/) instrumentation to a web, RPC, or other framework that makes requests and/or receives responses. This instrumentation makes it easy for developers using the framework to incorporate end-to-end (distributed) tracing.
 
-Distributed tracing provides insight about individual requests as they propagate throughout a system. OpenTracing is an open-source standard API for consistent distributed tracing of requests across processes, from web and mobile client platforms to the storage systems and custom backends at the bottom of an application stack. Once OpenTracing integrates across  the entire application stack, it’s easy to trace requests across the distributed system. This allows developers and operators much-needed visibility optimize and stabilize production services.
+Distributed tracing provides insight about individual requests as they propagate throughout a system. OpenTracing is an open-source standard API for consistent distributed tracing of requests across processes, from web and mobile client platforms to the storage systems and custom backends at the bottom of an application stack. Once OpenTracing integrates across  the entire application stack, it’s easy to trace requests across the distributed system. This allows developers and operators much-needed visibility to optimize and stabilize production services.
 
 Before you begin, check [here](/pages/api/api-implementations) to make sure that there's a working OpenTracing API for your platform.
 


### PR DESCRIPTION
- Fix capitalization of letters after period in CONTRIBUTING.md
- Add missing preposition in between docs of instrumenting-frameworks.md page