### PR TITLE
Update tracers.yaml

### DIFF
--- a/_data/tracers.yaml
+++ b/_data/tracers.yaml
@@ -25,7 +25,7 @@ array:
     icon: img/tracers/instana.svg
     
   - name: Skywalking
-    url: http://skywalking.org
+    url: http://skywalking.apache.org
     icon: img/tracers/skywalking.png
 
   - name: inspectIT


### PR DESCRIPTION
Update url of SkyWalking project based on @tiffon 's #265 

`http://skywalking.org` is no longer used by SkyWalking project. We have moved into 
http://skywalking.apache.org/ , and keep using http://skywalking.io