### PR TITLE
Add 2.0 announcement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 [![Build Status](https://api.travis-ci.org/opentracing/opentracing.io.svg?branch=master)](https://travis-ci.org/opentracing/opentracing.io)
 [![Join gitter channel](https://badges.gitter.im/opentracing/opentracing.io.svg)](https://gitter.im/opentracing/public)
 
+# ATTENTION: New website coming
+
+A new version of the website, based on hugo, is being developed on th `v2.0` branch:
+https://github.com/opentracing/opentracing.io/tree/v2.0
+
+Issues and PRs labeled `v2.0` are related to the new website.
+
+There will be a documentation hackation on **Wednesday, June 13th**. Check out the announcement for details and signup instructions:
+https://medium.com/opentracing/opentracing-docuthon-july-13th-f06aab7955fe
+
 # opentracing.io
 
 This repository contains the source code for http://opentracing.io website.


### PR DESCRIPTION
Since we are about to have a lot of 2.0 activity, it would help if the current readme pointed people to the new site.