### PR TITLE
Install note about proper Hugo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ under its [Apache 2.0 License](LICENSE.md).
 ## Local Development
 If youu'd like to work on the website locally, first install the site dependencies:
 * Install NPM: https://nodejs.org/en/ (NPM comes with NodeJS)
-* Install Hugo: https://gohugo.io/getting-started/installing/#quick-install
+* Install Hugo: https://gohugo.io/getting-started/installing/#quick-install (Version .41 required, easy to switch to with Homebrew: `brew switch hugo 0.41`)
 
 Once the above dependencies are installed, you can install the website. First, open up a terminal, navigate to the directory you would like to work in, and clone your fork of this repository. Then checkout the `v2.0` branch and install the website with the following commands:
 


### PR DESCRIPTION
There's a newer release of Hugo that breaks docs installation for me on Mac OS, .42.

I get an error `panic: AllThemes not set`, and the `make` command fails.

As a temporary workaround, adding a note about the proper version, and how to install it on Mac OS with Homebrew.