### PR TITLE
Added link to the Outreachy page and fixed permalink to old progam page

### DIFF
--- a/_data/links.yaml
+++ b/_data/links.yaml
@@ -42,3 +42,6 @@ community:
 
   - url: //github.com/opentracing-contrib/meta#opentracing-contributions
     name: Become a Contributor
+
+  - url: /outreachy
+    name: Outreachy

--- a/pages/outreachy-201702.md
+++ b/pages/outreachy-201702.md
@@ -1,5 +1,5 @@
 ---
-permalink: /outreachy.html
+permalink: /outreachy-201702.html
 layout: page-containing-markup
 title: 'Outreachy'
 ---


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

This PR fixes the URL to the second Outreachy program from 2017 and adds an Outreachy option to the Community drop down menu. Here's how it renders now:

![image](https://user-images.githubusercontent.com/13387/43827464-2d4f393e-9afa-11e8-8e4c-9b8f74718a6e.png)
