### PR TITLE
Add link to the OT-Contrib GitHub Page

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -12,6 +12,8 @@ docs:
     name: Translations
   - localUrl: /docs/faq
     name: FAQ
+  - url: //github.com/opentracing-contrib/meta
+    name: Registry
 
 guides:
   - localUrl: /guides/golang/

--- a/themes/tracer/layouts/partials/header.html
+++ b/themes/tracer/layouts/partials/header.html
@@ -79,6 +79,7 @@
       </div>
 
       <a href="https://medium.com/opentracing">Blog</a>
+      <a href="https://github.com/opentracing-contrib/meta">Registry</a>
     </div>
     <div class="header__actions right">
       <a class="button white" href="https://gitter.im/opentracing/public">Say hi on Gitter</a>


### PR DESCRIPTION
This adds a new link to the navbar ('Registry') that will currently point to the OT-Contrib meta page. Eventually, this will lead to the OT Registry page itself.