### PR TITLE
Restore old Outreachy pages that didn't make it over.

### DIFF
--- a/content/get-involved/outreachy/_index.md
+++ b/content/get-involved/outreachy/_index.md
@@ -1,0 +1,18 @@
+---
+title: Outreachy
+---
+
+OpenTracing and Jaeger are proud to participate in the Outreachy program. In this section, you can find information about our current, and past, Outreachy internship programs.
+
+Our current program can be found [here](/get-involved/outreachy/outreachy-201802)
+
+## What is Outreachy?
+
+(From [outreachy.org](https://outreachy.org))
+
+Outreachy provides three-month internships to work in Free and Open Source Software (FOSS). Interns are paid a stipend of $5,500 and have a $500 travel stipend available to them. Outreachy internship projects may include programming, user experience, documentation, illustration and graphical design, or data science. Interns often find employment after their internship with Outreachy sponsors or in jobs that use the skills they learned during their internship.
+
+Outreachy internships are open to applicants around the world. Interns work remotely with mentors from FOSS communities.
+
+We expressly invite women (both cis and trans), trans men, and genderqueer people to apply. We also expressly invite applications from residents and nationals of the United States of any gender who are Black/African American, Hispanic/Latin@, Native American/American Indian, Alaska Native, Native Hawaiian, or Pacific Islander. Anyone who faces under-representation, systemic bias, or discrimination in the technology industry of their country is invited to apply.
+

--- a/content/get-involved/outreachy/outreachy-201701.md
+++ b/content/get-involved/outreachy/outreachy-201701.md
@@ -1,0 +1,190 @@
+---
+title: Dec. 2017 - Mar. 2018
+---
+
+# Outreachy
+
+The OpenTracing and Jaeger projects are happy to announce our participation in the Outreachy program, running
+from December 2017 to March 2018. As part of this joint effort, we'll be collecting ideas for tasks related to
+OpenTracing, Jaeger or both that would be appropriate for an intern to work on.
+
+Please see the main [program page](https://outreachy.org) for the general information about the program, such
+as its purpose, timeline, eligibility requirements, and how to apply.
+
+## What is OpenTracing
+
+OpenTracing is a vendor-neutral open standard for distributed tracing. For the motivation behind OpenTracing,
+we recommend watching the presentations available at the page [Talks and Videos](/talks-and-videos).
+
+## What is Jaeger
+
+Jaeger is a concrete set of tracers and a trace storage backend, for usage on applications and microservices
+instrumented with OpenTracing. Its [GitHub main readme](https://github.com/jaegertracing/jaeger) is a good
+starting point to understand what is Jaeger and how to start using it.
+
+## Schedule
+- October ~~23~~ 30: - application deadline
+- November 9: - selection decisions are made
+- December 5 - March 5: - internship
+
+## Coordination
+
+* [Juraci Paixão Kröhling](https://github.com/jpkrohling)
+* [Gary Brown](https://github.com/objectiser)
+
+The coordinators can be contacted at any time. The easiest way is to send a message to the mailing list of either
+OpenTracing or Jaeger, as both coordinators are present on both mailing lists:
+
+* [OpenTracing Mailing List](https://groups.google.com/forum/#!forum/opentracing)
+* [Jaeger Mailing List](https://groups.google.com/forum/#!forum/jaeger-tracing)
+
+Another option is to use Gitter, which is the chat platform used by both the OpenTracing and Jaeger projects:
+
+* [OpenTracing Gitter Channel](http://gitter.im/opentracing/public)
+* [Jaeger Gitter Channel](https://gitter.im/jaegertracing/Lobby)
+
+## Mentors
+
+* [Gary Brown](https://github.com/objectiser)
+* [Pavol Loffay](https://github.com/pavolloffay)
+
+Similar to contacting the coordinators, the mentors can be contacted at any time either by sending messages to
+the mailing lists or Gitter channels.
+
+Interested in becoming a mentor? Contact one of the coordinators!
+
+## Contribute
+
+As part of the application process, the Outreachy program recommends that candidates make 
+[small contributions](https://www.outreachy.org/apply/make-contributions/) to the project they intend to apply for.
+
+The following [GitHub query](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Aopentracing+org%3Aopentracing-contrib+org%3Ajaegertracing+label%3Aoutreachy+) 
+gives a non-comprehensive list of tasks that might be suitable for that:
+
+`is:open is:issue org:opentracing org:opentracing-contrib org:jaegertracing label:outreachy`
+
+As a general rule, though, candidates are free to choose any issue within any repository belonging to the
+following organizations:
+
+* [opentracing](https://github.com/opentracing/)
+* [opentracing-contrib](https://github.com/opentracing-contrib/)
+* [jaegertracing](https://github.com/jaegertracing/)
+
+[All the issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Aopentracing+org%3Aopentracing-contrib+org%3Ajaegertracing) 
+from these three organizations can be seen with this query:
+
+`is:open is:issue org:opentracing org:opentracing-contrib org:jaegertracing`
+
+## Available tasks
+
+### Instrumentation for mobile applications
+
+Mentor: Gary Brown
+
+* Collect ideas on what's possible and what's desirable for mobile applications
+* Decide and experiment with different options for an optimized mobile experience, like, which sampling strategies
+make more sense
+* Create the missing pieces, like OpenTracing framework integration for some Android component, or a specific Jaeger
+tracer for mobile usage
+* Documentation + examples
+* The end result would be: a trace starts when a user opens the app on the phone and backend microservices are called
+
+Desired skills: Android, Java
+
+Optional skills: Building android applications, Kotlin
+
+### Split the Jaeger JavaScript OT library: NodeJS and Browser
+
+Mentor: Pavol Loffay
+
+* HttpSender which works in a web browser
+* Intercept web browser events (maybe can be done as OpenTracing instrumentation)
+
+Desired skills: Javascript
+
+### Document the feasibility or infeasibility of candidate format standards for trace/span data
+
+Mentor: Gary Brown
+
+The OpenTracing standard provides a programmatic API to enable applications to report tracing data in a vendor
+neutral way. Applications bind to tracing system specific tracers which report the tracing data to their own
+backend system in a vendor specific format.
+
+In some situations it would also be desirable to have a vendor neutral tracer bound in the application, reporting
+the tracing data in a standard format, which can then be consumed by different tracing systems.
+
+This project will be to conduct a survey of existing potential standard formats and document their suitability
+to represent the information captured via the OpenTracing API. The project will also include the development of
+a tracer (in any OpenTracing API supported language) to report the standard format, and a backend adapter
+to convert it for storage in Jaeger (written as a gateway in language of choice - although Go preferred).
+
+Desired skills: Any programming language with an OpenTracing API
+
+Optional skills: Go preferred for backend adapter, although will initially be implemented as separate gateway so other
+languages could be used.
+
+### OpenTracing MockTracer JUnit rule.
+
+Mentor: Pavol Loffay
+
+* Clear reported spans between tests. Automatically assert on errors.
+
+Desired skills: Java
+
+### Move community Jaeger tracers to the jaegertracing organization.
+
+Mentor: Gary Brown
+
+This task include writing integration tests, missing reporters. Candidates include:
+
+* [Ruby](https://github.com/salemove/jaeger-client-ruby)
+* [PHP](https://github.com/jukylin/jaeger-php)
+
+Desired skills: Proficiency in the relevant language
+
+### Create OpenTracing API for language not currently supported
+
+Mentor: Pavol Loffay
+
+* For instance, for missing Android parts.
+
+Desired skills: Proficiency in the chosen language
+
+### Write Jaeger tracer implementation for any OpenTracing API.
+
+Mentor: Gary Brown
+
+* C#
+* Kotlin for Android
+
+Desired skills: Proficiency in the chosen language
+
+
+### Conformance Test Suite for OpenTracing API
+
+Mentor: Pavol Loffay
+
+This project will provide a Conformance Test Suite for the OpenTracing API. This will involve:
+
+* Defining the conformance tests to be implemented
+* For one or more languages, implementing the tests
+* Demonstrate use of the test suite against multiple tracers
+
+Desired skills: Proficiency in the chosen language(s)
+
+
+Additionally to the tasks above, we recommend looking at the following issue trackers. You might want to pick
+an easy one before applying, to get a better sense of what the projects are about.
+
+* [OpenTracing issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Aopentracing)
+* [Jaeger issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Ajaegertracing)
+
+Do you have an idea for a task that is suitable for this program? Contact the mentors or coordinators! Or
+even better, volunteer for mentoring an intern during the work on your idea!
+
+## Code of Conduct
+
+Both OpenTracing and Jaeger are part of the Cloud Native Computing Foundation (CNCF) and have adopted its
+[Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+{% include cncf-foundation.html %}

--- a/content/get-involved/outreachy/outreachy-201801.md
+++ b/content/get-involved/outreachy/outreachy-201801.md
@@ -1,7 +1,5 @@
 ---
-permalink: /outreachy-201801.html
-layout: page-containing-markup
-title: 'Outreachy'
+title: May 2018 - Aug. 2018
 ---
 
 # Outreachy

--- a/content/get-involved/outreachy/outreachy-201802.md
+++ b/content/get-involved/outreachy/outreachy-201802.md
@@ -1,6 +1,6 @@
 ---
-title: Outreachy
-weight: 5
+title: Dec. 2018 - Mar. 2019
+weight: 20
 ---
 
 # Outreachy
@@ -120,8 +120,8 @@ Interested in this project? Here are a few tasks that might help you decide. If 
 
 OpenTracing and Jaeger participated in the following Outreachy programs:
 
-* [December 2017 to March 2018](/get-involved/outreachy)
-* [May 2018 to August 2018](/get-involved/outreachy)
+* [December 2017 to March 2018](/get-involved/outreachy/outreachy-201701)
+* [May 2018 to August 2018](/get-involved/outreachy/outreachy-201801)
 
 ## Code of Conduct
 

--- a/themes/tracer/layouts/get-involved/list.html
+++ b/themes/tracer/layouts/get-involved/list.html
@@ -1,10 +1,10 @@
 {{ define "main" }}
-{{- $filename := printf "/get-involved/%s.md" .Params.filename }}
+{{- $sections := where .Site.Sections "Section" "=" "get-involved" }}
 <div class="docs container">
   <section class="docs__main row">
     <nav class="docs__nav col-3">
       <div class="docs__nav__list">
-        {{ partial "nav.html" (where .Site.RegularPages "Section" "get-involved") }}
+        {{partial "menu.html" $sections}}
       </div>
     </nav>
 

--- a/themes/tracer/layouts/get-involved/single.html
+++ b/themes/tracer/layouts/get-involved/single.html
@@ -1,10 +1,10 @@
 {{ define "main" }}
-{{- $filename := printf "/get-involved/%s.md" .Params.filename }}
+{{- $sections := where .Site.Sections "Section" "=" "get-involved" }}
 <div class="docs container">
   <section class="docs__main row">
     <nav class="docs__nav col-3">
       <div class="docs__nav__list">
-        {{ partial "nav.html" (where .Site.RegularPages "Section" "get-involved") }}
+        {{partial "menu.html" $sections}}
       </div>
     </nav>
 

--- a/themes/tracer/layouts/partials/header.html
+++ b/themes/tracer/layouts/partials/header.html
@@ -53,15 +53,12 @@
       <div class="dropdown">
         <a class="dropdown__button" href="/get-involved">Get Involved</a>
         <div class="dropdown__content docs">
-          <!-- {{- range .Site.Data.links.getInvolved }}
+          {{- range .Site.Data.links.getInvolved }}
           {{- if .url }}
           <a href="{{ .url }}">{{ .name }}</a>
           {{- else }}
           <a href="{{ .localUrl }}">{{ .name }}</a>
           {{- end }}
-          {{- end }} -->
-          {{- range (where .Site.RegularPages "Section" "get-involved").ByWeight }}
-          <a href="{{ .Permalink }}">{{ .Title }}</a>
           {{- end }}
         </div>
       </div>


### PR DESCRIPTION
Fixes #344 

I also refactored the menu in get-involved to match the docs/guides one and put the outreachy stuff in a subsection to be consistent with other parts of the site.