### PR TITLE
Removing specific author attribution

### DIFF
--- a/content/registry/brave-tracer-java.md
+++ b/content/registry/brave-tracer-java.md
@@ -9,7 +9,6 @@ tags:
 repo: https://github.com/openzipkin/brave-opentracing
 license: Apache
 description: A bridge to Brave that exposes the OpenTracing API
-authors: Adrian Cole <acole@pivotal.io>
 otVersion: 0.31
 ---
 


### PR DESCRIPTION
We discussed and we want to remove individual attribution for our stuff since it is collectively owned and maintained