### PR TITLE
Add AppOptics tracer to the OpenTracing Registry

### DIFF
--- a/content/registry/go-tracer-appoptics.md
+++ b/content/registry/go-tracer-appoptics.md
@@ -1,0 +1,15 @@
+---
+title: AppOptics Tracer for Go
+registryType: tracer
+tags:
+  - go
+  - appoptics
+  - solarwinds
+  - golang
+  - tracer
+repo: https://github.com/appoptics/appoptics-apm-go
+license: "Librato Open License"
+description: "AppOptics APM instrumentation SDK for Go, including an OpenTracing tracer."
+authors: AppOptics
+otVersion: 1.0.2
+---


### PR DESCRIPTION
adds a mention of the OT tracer in https://github.com/appoptics/appoptics-apm-go