### PR TITLE
Featured Medium post should be most recent post

### DIFF
--- a/themes/tracer/layouts/partials/home/cncf.html
+++ b/themes/tracer/layouts/partials/home/cncf.html
@@ -4,3 +4,4 @@
     <img src="/img/cncf-logo.png" alt="">
   </div>
 </section>
+

--- a/themes/tracer/layouts/partials/home/hero.html
+++ b/themes/tracer/layouts/partials/home/hero.html
@@ -16,23 +16,19 @@
         </p>
       </div>
       {{- with $hero.update -}}
+      <h4>The latest from our blog:</h4>
       <div id="update" class="update">
         <a href="" target="_blank">
         </a>
-        <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
         <script type="text/javascript">
-          $(function() {
-              var $content = $('#update');
-              var data = {
-                  rss_url: 'https://medium.com/feed/opentracing'
-              };
-            $.get('https://api.rss2json.com/v1/api.json', data, function(response) {
-                  if (response.status == 'ok') {
-                    var output = '<a href="' + response.items[0].link + '" target="_blank">' + response.items[0].title + '</a>'
-                  $content.html(output);
-                  }
+          fetch('https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fopentracing')
+            .then(function(res) {
+              res.json().then(function(data) {
+                let item = data.items[0];
+                let content = `<a href="${item.link}" target="_blank">${item.title}</a>`;
+                document.getElementById('update').innerHTML = content;
+              });
             });
-          });
       </script>
       </div>
       {{- end -}}

--- a/themes/tracer/layouts/partials/home/hero.html
+++ b/themes/tracer/layouts/partials/home/hero.html
@@ -28,6 +28,9 @@
                 let content = `<a href="${item.link}" target="_blank">${item.title}</a>`;
                 document.getElementById('update').innerHTML = content;
               });
+            }).catch(function() {
+              let content = `<a href="https://medium.com/opentracing" target="_blank">OpenTracing on Medium</a>`
+              document.getElementById('update').innerHTML = content;
             });
       </script>
       </div>

--- a/themes/tracer/layouts/partials/home/hero.html
+++ b/themes/tracer/layouts/partials/home/hero.html
@@ -16,10 +16,24 @@
         </p>
       </div>
       {{- with $hero.update -}}
-      <div class="update">
-        <a href="{{ .url }}" target="_blank">
-          {{ .title }}
+      <div id="update" class="update">
+        <a href="" target="_blank">
         </a>
+        <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+        <script type="text/javascript">
+          $(function() {
+              var $content = $('#update');
+              var data = {
+                  rss_url: 'https://medium.com/feed/opentracing'
+              };
+            $.get('https://api.rss2json.com/v1/api.json', data, function(response) {
+                  if (response.status == 'ok') {
+                    var output = '<a href="' + response.items[0].link + '" target="_blank">' + response.items[0].title + '</a>'
+                  $content.html(output);
+                  }
+            });
+          });
+      </script>
       </div>
       {{- end -}}
     </section>


### PR DESCRIPTION
This adds some dynamic fetching of the Medium RSS feed in order to display the most recent post on the frontpage rather than using the site data supplied URL.