### PR TITLE
Fix bashWindowText to match change in opentracing-contrib/examples

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ params:
       url: https://medium.com/opentracing/february-2018-opentracing-monthly-newsletter-7700560e9b04
     bashWindowText: |
       # Start Jaeger locally
-      $ docker run -d -p 5775:5775/udp -p 16686:16686 jaegertracing/all-in-one:latest
+      $ docker run -d -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:latest
       $ export DOCKER_IP=`docker-machine ip $(docker-machine active)`
       $ cd $GOPATH/src
 


### PR DESCRIPTION
Since
https://github.com/opentracing-contrib/examples/commit/dd9b3e3c349748805c619c7950938345d240e51e
landed, the go example mentioned in `bashWindowText` produces jaeger.thrift instead
of zipkin.thrift, and consequently hits udp port 6831 instead of udp port 5775.

Not sure if `content/docs/getting-started/_index.md` also needs to change.