### PR TITLE
Add Python Requests instrumentation

### DIFF
--- a/content/registry/python-requests.md
+++ b/content/registry/python-requests.md
@@ -1,0 +1,12 @@
+---
+title: python-requests
+registryType: instrumentation
+tags:
+  - opentracing
+  - Python
+repo: https://github.com/opentracing-contrib/python-requests
+license: Apache License 2.0
+description: OpenTracing instrumentation for Requests
+authors: OpenTracing Contributors
+otVersion: latest
+---


### PR DESCRIPTION
Includes registry entry for https://github.com/opentracing-contrib/python-requests