### PR TITLE
Add Python DB API instrumentation

### DIFF
--- a/content/registry/python-dbapi.md
+++ b/content/registry/python-dbapi.md
@@ -1,0 +1,12 @@
+---
+title: python-dbapi
+registryType: instrumentation
+tags:
+  - opentracing
+  - Python
+repo: https://github.com/opentracing-contrib/python-dbapi
+license: Apache License 2.0
+description: OpenTracing instrumentation for the Python DB API
+authors: OpenTracing Contributors
+otVersion: latest
+---


### PR DESCRIPTION
Includes registry entry for https://github.com/opentracing-contrib/python-dbapi