### PR TITLE
Fix broken link on python/tracers

### DIFF
--- a/content/guides/python/tracers.md
+++ b/content/guides/python/tracers.md
@@ -129,6 +129,6 @@ def format():
 
 ```
 
-Other implemented examples of inject/extract and details can be found [here](./inject-extract).
+Other implemented examples of inject/extract and details can be found [here](../inject-extract).
 
 ![Trace Propagation](/img/overview:tracers/Extract.png)


### PR DESCRIPTION
The link for inject-extract on guides/python/tracers was 404'ing.
Link this to the correct path