### PR TITLE
Add nodetracing to the registry

### DIFF
--- a/content/registry/nodetracing.md
+++ b/content/registry/nodetracing.md
@@ -1,0 +1,14 @@
+---
+title: nodetracing
+registryType: tracer
+tags:
+    - nodejs
+    - webui
+    - docker
+    - opentracing
+repo: https://github.com/cheneyweb/nodetracing
+license: Apache License 2.0
+description: Automatic instrumentation and tracer of nodejs application, support asyncfunction/http/grpc/axios/express/koa etc.
+authors: CheneyXu <457299596@qq.com>
+otVersion: latest
+---


### PR DESCRIPTION
---
title: nodetracing
registryType: tracer
tags:
    - nodejs
    - webui
    - docker
    - opentracing
repo: https://github.com/cheneyweb/nodetracing
license: Apache License 2.0
description: Automatic instrumentation and tracer of nodejs application, support asyncfunction/http/grpc/axios/express/koa etc.
authors: CheneyXu <457299596@qq.com>
otVersion: latest
---