### PR TITLE
update registry entry for Datadog .NET Tracer

### DIFF
--- a/content/registry/dd-trace-dotnet.md
+++ b/content/registry/dd-trace-dotnet.md
@@ -2,11 +2,12 @@
 title: Datadog Tracing .NET Client
 registryType: tracer
 tags:
-  - dotnet
+  - .net
   - datadog
   - tracer
 repo: https://github.com/DataDog/dd-trace-dotnet
-license: BSD
+license: Apache License 2.0
 description: Datadog tracing library for .NET
 authors: Datadog
+otVersion: 0.12
 ---


### PR DESCRIPTION
- add supported OpenTracing version
- fix incorrect license
- rename tag for consistency