### PR TITLE
Add contribution: opentracing-basic lib for java

### DIFF
--- a/content/registry/java-opentracing-basic.md
+++ b/content/registry/java-opentracing-basic.md
@@ -6,7 +6,7 @@ tags:
   - java
 repo: https://github.com/eBay/opentracing-basic/
 license: Apache 2.0
-description: Basic OpenTracing bridge/stub library for Java
+description: The goal of this library is to attempt to implement the generic semantics of the OpenTracing API and allow for the main implementation details to be provided into the library by the consumer.
 authors: Mike Cumings
 otVersion: latest
 ---

--- a/content/registry/java-opentracing-basic.md
+++ b/content/registry/java-opentracing-basic.md
@@ -1,0 +1,12 @@
+---
+title: opentracing-basic
+registryType: tracer
+tags:
+  - opentracing
+  - java
+repo: https://github.com/eBay/opentracing-basic/
+license: Apache 2.0
+description: Basic OpenTracing bridge/stub library for Java
+authors: Mike Cumings
+otVersion: latest
+---


### PR DESCRIPTION
Adds reference to the opentracing-basic lib here: https://github.com/eBay/opentracing-basic/