### PR TITLE
Add opentracing-java-aws-xray to registry

### DIFF
--- a/content/registry/java-aws-xray.md
+++ b/content/registry/java-aws-xray.md
@@ -1,0 +1,14 @@
+---
+title: AWS X-Ray Tracing Java Client
+registryType: tracer
+tags:
+    - opentracing
+    - java
+    - aws
+    - xray
+repo: https://github.com/skylight-ipv/opentracing-java-aws-xray
+license: Apache License 2.0
+description: Client library for the AWS X-Ray tracer that supports Java
+authors: Ashley Mercer <13454082+ashleymercer@users.noreply.github.com>
+otVersion: 0.31
+---


### PR DESCRIPTION
We've written a thin wrapper to implement the OpenTracing API around the AWS X-Ray SDK. I'd like to add this to the registry since there doesn't seem to be an implementation yet, and I think this would be useful to the broader OpenTracing community.