### PR TITLE
Add some height to the Elastic logo

### DIFF
--- a/themes/tracer/assets/scss/_components/_logo-bar.scss
+++ b/themes/tracer/assets/scss/_components/_logo-bar.scss
@@ -97,6 +97,11 @@ $logo-bar-scale: 14px;
         &[src*="finagle"] {
           max-height: $logo-bar-scale * 1.1;
         }
+
+        &[src*="elastic.png"] {
+          max-height: $logo-bar-scale * 1.5;
+          height: $logo-bar-scale + 8;
+        }
       }
     }
   }


### PR DESCRIPTION
Due to the dimensions of the Elastic logo, it is being
scaled in such a way as to look awkward and out of place
in the carousel. Tweak its height and max-height slightly.

Before:
![before](https://user-images.githubusercontent.com/843579/53847221-c4e8d080-3fea-11e9-9d2d-8ff03cb36c5e.png)

After:
![after](https://user-images.githubusercontent.com/843579/53847226-c87c5780-3fea-11e9-9b78-a4d666f495f1.png)