### PR TITLE
Fix typo and indentation in Opentracing Java documentation 

### DIFF
--- a/content/guides/java/_index.md
+++ b/content/guides/java/_index.md
@@ -51,28 +51,28 @@ Besides the official API, there are also several libraries under [opentracing-co
 An easy way to get quickly started, and get familiar with the API is to use **io.opentracing.mock.MockTracer** to create **Span**s and inspect them afterwards, as the resulting **MockSpan**s will expose a lot of information that a normal **Span** would not.
 
 ```java
-  import java.util.Map;
-  import io.opentracing.mock.MockTracer;
-  import io.opentracing.mock.MockSpan;
-  import io.opentracing.tags.Tags;
+import java.util.Map;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.tags.Tags;
 
-  // Initialize MockTracer with the default values.
-  MockTracer tracer = new MockTracer();
+// Initialize MockTracer with the default values.
+MockTracer tracer = new MockTracer();
 
-  // Create a new Span, representing an operation.
-  MockSpan span = tracer.buildSpan("foo").start();
+// Create a new Span, representing an operation.
+MockSpan span = tracer.buildSpan("foo").start();
 
-  // Add a tag to the Span.
-  span.setTag(Tags.COMPONENT, "my-own-application");
+// Add a tag to the Span.
+span.setTag(Tags.COMPONENT, "my-own-application");
 
-  // Finish the Span.
-  span.finish();
+// Finish the Span.
+span.finish();
 
-  // Analize the saved Span.
-  System.out.println("Operation name = " + span.operationName());
-  System.out.println("Start = " + span.startMicros());
-  System.out.println("Finish = " + span.finishMicros());
+// Analyze the saved Span.
+System.out.println("Operation name = " + span.operationName());
+System.out.println("Start = " + span.startMicros());
+System.out.println("Finish = " + span.finishMicros());
 
-  // Inspect the Span's tags.
-  Map<String, Object> tags = span.tags();
+// Inspect the Span's tags.
+Map<String, Object> tags = span.tags();
 ```


### PR DESCRIPTION
Fix a simple typo in the comments and unindent the code so it lines up properly on the left. 