### PR TITLE
guides/golang: fix quick-start compile error

### DIFF
--- a/content/guides/golang/quick-start.md
+++ b/content/guides/golang/quick-start.md
@@ -96,7 +96,7 @@ childSpan := tracer.StartSpan(
     "child",
     opentracing.ChildOf(parentSpan.Context()),
 )
-defer childSpan.finish()
+defer childSpan.Finish()
 ```
 
 ## Make an HTTP request


### PR DESCRIPTION
Ran into this when setting up a test-case for myself.

```
internal/trace/trace_test.go:24:7: child.finish undefined (type opentracing.Span has no field or method finish, but does have Finish)
```