### PR TITLE
instrumentation of newest go-redis

### DIFF
--- a/content/registry/go-opentracing-go-redis
+++ b/content/registry/go-opentracing-go-redis
@@ -6,7 +6,7 @@ tags:
     - redis
     - go-redis
 repo: https://github.com/lyb0307/opentracing-go-redis
-license: WTFPL
+license: MIT
 description: I searched for the redis client of golang with opentracing, they are all out of date. 
              I noticed there was an instrumentation of go-redis (https://github.com/opentracing-contrib/goredis) supports the v6 version of go-redis. 
              While the latest version is v8 and they have changed their "WrapProcess" method to "Hook" interface.

--- a/content/registry/go-opentracing-go-redis
+++ b/content/registry/go-opentracing-go-redis
@@ -1,0 +1,18 @@
+---
+title: opentracing-go-redis
+registryType: instrumentation
+tags:
+    - golang
+    - redis
+    - go-redis
+repo: https://github.com/lyb0307/opentracing-go-redis
+license: WTFPL
+description: I searched for the redis client of golang with opentracing, they are all out of date. 
+             I noticed there was an instrumentation of go-redis (https://github.com/opentracing-contrib/goredis) supports the v6 version of go-redis. 
+             While the latest version is v8 and they have changed their "WrapProcess" method to "Hook" interface.
+             Also I noticed go-redis has their own tracing based on OpenTelemetry (https://redis.uptrace.dev/tracing/).
+             So I just modified it to support opentracing.
+             Here it is.
+authors: lyb0307
+otVersion: latest
+---


### PR DESCRIPTION
I searched for the redis client of golang with opentracing, they are all out of date. 
I noticed there was an instrumentation of go-redis (https://github.com/opentracing-contrib/goredis) supports the v6 version of go-redis. 
While the latest version is v8 and they have changed their "WrapProcess" method to "Hook" interface.
Also I noticed go-redis has their own tracing based on OpenTelemetry (https://redis.uptrace.dev/tracing/).
So I just modified it to support opentracing.
Here it is.