### PR TITLE
Create javascript-foxx-tracer.md

### DIFF
--- a/content/registry/javascript-foxx-tracer.md
+++ b/content/registry/javascript-foxx-tracer.md
@@ -1,6 +1,6 @@
 ---
 title: foxx-tracer - An instrumentation library for Foxx Microservices
-registryType: <instrumentation/tracer>
+registryType: tracer
 tags:
     - javascript
     - foxx

--- a/content/registry/javascript-foxx-tracer.md
+++ b/content/registry/javascript-foxx-tracer.md
@@ -1,0 +1,14 @@
+---
+title: foxx-tracer - An instrumentation library for Foxx Microservices
+registryType: <instrumentation/tracer>
+tags:
+    - javascript
+    - foxx
+    - arangodb
+    - synchronous
+repo: https://github.com/RecallGraph/foxx-tracer
+license: MIT
+description: Most tracing libraries in the nodeverse are asynchronous, and so do not work in the synchronous V8 runtime that ArangoDB uses to run its Foxx services. _foxx-tracer_ bridges this gap by being a 100% synchronous, dedicated module built for the Foxx runtime.
+authors: Aditya Mukhopadhyay <webmaster@adityamukho.com>
+otVersion: latest
+---


### PR DESCRIPTION
Most tracing libraries in the nodeverse are asynchronous, and so do not work in the synchronous V8 runtime that ArangoDB uses to run its Foxx services. _foxx-tracer_ bridges this gap by being a 100% synchronous, dedicated module built for the Foxx runtime.