### PR TITLE
Add go-redis-v8 instrumentation

### DIFF
--- a/content/registry/go-opentracing-redis-v8.md
+++ b/content/registry/go-opentracing-redis-v8.md
@@ -1,0 +1,13 @@
+---
+title: go-redis-v8
+registryType: instrumentation
+tags:
+    - Go
+    - redis
+    - go-redis v8
+repo: https://github.com/laststem/go-opentracing-redis
+license: MIT
+description: opentracing module for go-redis (latest version)
+authors: laststem <laststem@gmail.com>
+otVersion: latest
+---


### PR DESCRIPTION
[registry](https://opentracing.io/registry/) does not have a instrumentation that supports [go-redis](https://github.com/go-redis/redis), so I want to add it.