### PR TITLE
Noindex & nofollow site pages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 title: The OpenTracing project
 baseURL: /
 languageCode: en-us
-enableRobotsTXT: true
 
 pygmentsUseClasses: true
 pygmentsCodefences: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 title: The OpenTracing project
 baseURL: /
 languageCode: en-us
+enableRobotsTXT: true
 
 pygmentsUseClasses: true
 pygmentsCodefences: true

--- a/themes/tracer/layouts/partials/seo.html
+++ b/themes/tracer/layouts/partials/seo.html
@@ -8,7 +8,9 @@
   gtag('config', 'UA-128661814-1');
 </script>
 
-{{ $keywords := .Params.keywords }}
+<meta name="robots" content="noindex, nofollow">
+
+{{- $keywords := .Params.keywords -}}
 {{ with $keywords }}<meta property="keywords" content="{{ delimit . ", " }}" />{{ end }}
 
 <!-- OpenGraph -->

--- a/themes/tracer/layouts/partials/seo.html
+++ b/themes/tracer/layouts/partials/seo.html
@@ -8,9 +8,11 @@
   gtag('config', 'UA-128661814-1');
 </script>
 
+{{ if ne .Kind "home" -}}
 <meta name="robots" content="noindex, nofollow">
+{{- end -}}
 
-{{- $keywords := .Params.keywords -}}
+{{ $keywords := .Params.keywords -}}
 {{ with $keywords }}<meta property="keywords" content="{{ delimit . ", " }}" />{{ end }}
 
 <!-- OpenGraph -->


### PR DESCRIPTION
- Addresses https://github.com/open-telemetry/opentelemetry.io/issues/1316

Preview:

- https://deploy-preview-462--opentracing.netlify.app, has no "noindex" tag value
- https://deploy-preview-462--opentracing.netlify.app/specification/, then View Source to see the robots meta tag with noindex.

/cc @austinlparker @yurishkuro @tedsuo @caniszczyk 